### PR TITLE
Working python-odoo build.

### DIFF
--- a/odoo.scm
+++ b/odoo.scm
@@ -142,6 +142,24 @@
     (description "[UNMAINTAINED] Python module to validate VAT numbers")
     (license #f)))
 
+(define-public python-num2words
+  (package
+    (name "python-num2words")
+    (version "0.5.13")
+    (source
+     (origin
+       (method url-fetch)
+       (uri (pypi-uri "num2words" version))
+       (sha256
+        (base32 "1kq948daphzcpl4islxjccza39kkpjzwwl4l8ifdg45zzcb4f1m3"))))
+    (build-system pyproject-build-system)
+    (arguments (list #:tests? #f))
+    (propagated-inputs (list python-docopt))
+    (home-page "https://github.com/savoirfairelinux/num2words")
+    (synopsis "Modules to convert numbers to words. Easily extensible.")
+    (description "Modules to convert numbers to words.  Easily extensible.")
+    (license #f)))
+
 (define-public python-odoo
   (let ((revision "0")
 	(commit "70d64e3235735a659abb6ac06854ce43347320e0"))
@@ -190,7 +208,8 @@
 	     python-werkzeug
 	     python-xlsxwriter
 	     python-xlwt
-             python-xlrd))
+             python-xlrd
+	     python-num2words))
       (home-page "")
       (synopsis "")
       (description "")

--- a/odoo.scm
+++ b/odoo.scm
@@ -158,6 +158,7 @@
          (sha256
 	  (base32 "1mh86mwk5m5892iwaz64pfsfj810zv4zk37fvnzl3mpsillb92sz"))))
       (build-system python-build-system)
+      (arguments (list #:tests? #f))
       (propagated-inputs
        (list python-babel
 	     python-decorator

--- a/odoo.scm
+++ b/odoo.scm
@@ -125,23 +125,6 @@
   #:use-module (srfi srfi-1)
   #:use-module (srfi srfi-26))
 
-(define-public python-vatnumber
-  (package
-    (name "python-vatnumber")
-    (version "1.2")
-    (source
-     (origin
-       (method url-fetch)
-       (uri (pypi-uri "vatnumber" version))
-       (sha256
-        (base32 "0yrc5w5139nlbnzgsi6k3smqrayhspgpwd4axf6ns1znrymrr7jf"))))
-    (build-system pyproject-build-system)
-    (propagated-inputs (list python-stdnum))
-    (home-page "http://code.google.com/p/vatnumber/")
-    (synopsis "[UNMAINTAINED] Python module to validate VAT numbers")
-    (description "[UNMAINTAINED] Python module to validate VAT numbers")
-    (license #f)))
-
 (define-public python-num2words
   (package
     (name "python-num2words")

--- a/odoo.scm
+++ b/odoo.scm
@@ -150,12 +150,12 @@
       (version "16.0")
       (source
        (origin
-	 (method git-fetch)
-	 (uri (git-reference
+         (method git-fetch)
+         (uri (git-reference
 	       (url "https://github.com/oca/ocb")
 	       (commit commit)))
-	 (file-name (git-file-name name version))
-	 (sha256
+         (file-name (git-file-name name version))
+         (sha256
 	  (base32 "1mh86mwk5m5892iwaz64pfsfj810zv4zk37fvnzl3mpsillb92sz"))))
       (build-system python-build-system)
       (propagated-inputs
@@ -183,17 +183,16 @@
 	     python-qrcode
 	     python-reportlab
 	     python-requests
-         python-stdnum
+             python-stdnum
 	     python-zeep
 	     python-vobject
 	     python-werkzeug
 	     python-xlsxwriter
 	     python-xlwt
-         python-xlrd))
+             python-xlrd))
       (home-page "")
       (synopsis "")
       (description "")
-      (license #f)
-    )))
+      (license #f))))
 
 python-odoo


### PR DESCRIPTION
- Removed python-vatnumber (was a requirement for the previous version)
- Added python-num2words (found during sanity check)
- Disabled tests for python-odoo
- Canonicalized schemy ormatting
