### PR TITLE
Build with tests

### DIFF
--- a/odoo.scm
+++ b/odoo.scm
@@ -159,7 +159,7 @@
          (sha256
 	  (base32 "1mh86mwk5m5892iwaz64pfsfj810zv4zk37fvnzl3mpsillb92sz"))))
       (build-system python-build-system)
-      (arguments (list #:tests? #f))
+      ; (arguments (list #:tests? #f))
       (propagated-inputs
        (list python-babel
 	     python-decorator
@@ -185,14 +185,15 @@
 	     python-qrcode
 	     python-reportlab
 	     python-requests
-             python-stdnum
+       python-stdnum
 	     python-zeep
 	     python-vobject
 	     python-werkzeug
 	     python-xlsxwriter
 	     python-xlwt
-             python-xlrd
-	     python-num2words))
+       python-xlrd
+	     python-num2words
+       python-freezegun))
       (home-page "")
       (synopsis "")
       (description "")

--- a/odoo.scm
+++ b/odoo.scm
@@ -192,8 +192,10 @@
 	     python-xlsxwriter
 	     python-xlwt
        python-xlrd
-	     python-num2words
-       python-freezegun))
+	     python-num2words))
+      (native-inputs (
+        list python-freezegun
+      ))
       (home-page "")
       (synopsis "")
       (description "")


### PR DESCRIPTION
Tests cannot be executed as a normal python package.
Odoo tests are automatically run when installing or updating modules if [--test-enable](https://www.odoo.com/documentation/16.0/developer/reference/cli.html#cmdoption-odoo-bin-test-enable) was enabled when starting the Odoo server.
Reference: https://www.odoo.com/documentation/16.0/developer/reference/backend/testing.html#running-tests